### PR TITLE
Manipulating order items + validation test coverage

### DIFF
--- a/src/Controller/EditOrderAction.php
+++ b/src/Controller/EditOrderAction.php
@@ -35,9 +35,9 @@ final class EditOrderAction
         $order = $this->oldOrderProvider->prepareToUpdate($id);
 
         $oldOrder = clone $order;
-        $updatedOrder = $this->updatedOrderProvider->provideFromOldOrderAndRequest($order, $request);
 
         try {
+            $updatedOrder = $this->updatedOrderProvider->provideFromOldOrderAndRequest($order, $request);
             $this->updatedOrderProcessor->process($updatedOrder);
             $this->postUpdateChangesChecker->check($oldOrder, $updatedOrder);
             $this->entityManager->flush();


### PR DESCRIPTION
Based on https://github.com/Setono/sylius-order-edit-plugin/pull/3

[This commit](https://github.com/Setono/sylius-order-edit-plugin/commit/685ea233a9a21899930c7bfbaf3c9b0d753f1834) covers adding and removing order items with tests, as well as order total check.