### PR TITLE
Fix adding order line error

### DIFF
--- a/src/Form/Extension/OrderTypeExtension.php
+++ b/src/Form/Extension/OrderTypeExtension.php
@@ -24,7 +24,7 @@ final class OrderTypeExtension extends AbstractTypeExtension
 
             $form
                 ->add('items', OrderItemCollectionType::class, [
-                    'entry_options' => ['currency_code' => $order->getCurrencyCode()]
+                    'entry_options' => ['currency_code' => $order->getCurrencyCode()],
                 ])
             ;
 

--- a/src/Form/Extension/OrderTypeExtension.php
+++ b/src/Form/Extension/OrderTypeExtension.php
@@ -17,14 +17,16 @@ final class OrderTypeExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('items', OrderItemCollectionType::class)
-        ;
-
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
             $form = $event->getForm();
             /** @var OrderInterface $order */
             $order = $event->getData();
+
+            $form
+                ->add('items', OrderItemCollectionType::class, [
+                    'entry_options' => ['currency_code' => $order->getCurrencyCode()]
+                ])
+            ;
 
             $form->add('discounts', OrderDiscountCollectionType::class, [
                 'property_path' => 'adjustments',

--- a/src/Form/Type/OrderItemCollectionType.php
+++ b/src/Form/Type/OrderItemCollectionType.php
@@ -17,6 +17,7 @@ final class OrderItemCollectionType extends AbstractType
             'allow_add' => true,
             'allow_delete' => true,
             'by_reference' => false,
+            'prototype' => true,
         ]);
     }
 

--- a/src/Form/Type/OrderItemType.php
+++ b/src/Form/Type/OrderItemType.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Setono\SyliusOrderEditPlugin\Form\Type;
 
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductVariant;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
@@ -14,8 +13,6 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class OrderItemType extends AbstractResourceType
@@ -47,6 +44,7 @@ final class OrderItemType extends AbstractResourceType
             ])
         ;
 
+        /** @var string $currencyCode */
         $currencyCode = $options['currency_code'];
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($currencyCode): void {
@@ -75,5 +73,6 @@ final class OrderItemType extends AbstractResourceType
         parent::configureOptions($resolver);
 
         $resolver->setRequired('currency_code');
+        $resolver->setAllowedTypes('currency_code', 'string');
     }
 }

--- a/src/Form/Type/OrderItemType.php
+++ b/src/Form/Type/OrderItemType.php
@@ -14,6 +14,9 @@ use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class OrderItemType extends AbstractResourceType
 {
@@ -44,21 +47,15 @@ final class OrderItemType extends AbstractResourceType
             ])
         ;
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
-            $form = $event->getForm();
-            /** @var OrderItemInterface|null $orderItem */
-            $orderItem = $event->getData();
-            if ($orderItem === null) {
-                return;
-            }
+        $currencyCode = $options['currency_code'];
 
-            /** @var OrderInterface $order */
-            $order = $orderItem->getOrder();
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($currencyCode): void {
+            $form = $event->getForm();
 
             $form->add('discounts', OrderItemDiscountCollectionType::class, [
                 'property_path' => 'adjustments',
                 'entry_options' => [
-                    'currency' => $order->getCurrencyCode(),
+                    'currency' => $currencyCode,
                 ],
             ]);
         });
@@ -71,5 +68,12 @@ final class OrderItemType extends AbstractResourceType
             }
             $event->setData($orderItem);
         });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setRequired('currency_code');
     }
 }

--- a/tests/Application/templates/bundles/SyliusAdminBundle/Order/Show/Summary/_item.html.twig
+++ b/tests/Application/templates/bundles/SyliusAdminBundle/Order/Show/Summary/_item.html.twig
@@ -49,11 +49,14 @@
         {{ money.format(item.total, order.currencyCode) }}
     </td>
 </tr>
+{% set discounts = item.getAdjustments(adminOrderItemDiscountAdjustment) %}
+{% if discounts is not empty %}
 <tr>
     <td colspan="9">
         <strong>{{ 'setono_sylius_order_edit.ui.discounts'|trans }}:</strong>
-        {% for discount in item.getAdjustments(adminOrderItemDiscountAdjustment) %}
+        {% for discount in discounts %}
             {{ money.format(discount.amount, order.currencyCode) }}{% if not loop.last %}, {% endif %}
         {% endfor %}
     </td>
 </tr>
+{% endif %}


### PR DESCRIPTION
Fixes https://github.com/Setono/sylius-order-edit-plugin/issues/16

The `discounts` field was not added to the new order line. It is now :dancer: 

Bonus: item discounts row is not now displayed on the show page if there are no discounts 🎉 