### PR TITLE
Display order totals

### DIFF
--- a/src/Resources/views/admin/order/update/_order_items.html.twig
+++ b/src/Resources/views/admin/order/update/_order_items.html.twig
@@ -61,3 +61,8 @@
     <h4 class="ui dividing header">{{ 'setono_sylius_order_edit.ui.order_discounts'|trans }}</h4>
     {{ form_widget(form.discounts) }}
 </div>
+<div class="ui segment big">
+    <h4 class="ui dividing header">{{ 'sylius.ui.order_summary'|trans }}</h4>
+    <br/>{{ 'sylius.ui.items_total'|trans }}: {{ money.format(order.itemsTotal, order.currencyCode) }}
+    <br/><br/>{{ 'sylius.ui.order_total'|trans }}: {{ money.format(order.total, order.currencyCode) }}
+</div>

--- a/src/Resources/views/admin/order/update/_order_items.html.twig
+++ b/src/Resources/views/admin/order/update/_order_items.html.twig
@@ -61,8 +61,9 @@
     <h4 class="ui dividing header">{{ 'setono_sylius_order_edit.ui.order_discounts'|trans }}</h4>
     {{ form_widget(form.discounts) }}
 </div>
-<div class="ui segment big">
+<div class="ui segment">
     <h4 class="ui dividing header">{{ 'sylius.ui.order_summary'|trans }}</h4>
     <br/>{{ 'sylius.ui.items_total'|trans }}: {{ money.format(order.itemsTotal, order.currencyCode) }}
-    <br/><br/>{{ 'sylius.ui.order_total'|trans }}: {{ money.format(order.total, order.currencyCode) }}
+    <br/>{{ 'sylius.ui.shipping_total'|trans }}: {{ money.format(order.shippingTotal, order.currencyCode) }}
+    <br/><br/><span class="ui large header">{{ 'sylius.ui.order_total'|trans }}: {{ money.format(order.total, order.currencyCode) }}</span>
 </div>


### PR DESCRIPTION
Fixes https://github.com/Setono/sylius-order-edit-plugin/issues/12

Something like this? @loevgaard 

<img width="1496" alt="Zrzut ekranu 2024-06-26 o 15 05 28" src="https://github.com/Setono/sylius-order-edit-plugin/assets/6212718/e2603b06-9508-4049-a235-c690459caf3f">
