### PR TITLE
Add delete button to new order item

### DIFF
--- a/src/Form/Type/OrderItemCollectionType.php
+++ b/src/Form/Type/OrderItemCollectionType.php
@@ -17,7 +17,6 @@ final class OrderItemCollectionType extends AbstractType
             'allow_add' => true,
             'allow_delete' => true,
             'by_reference' => false,
-            'prototype' => true,
         ]);
     }
 

--- a/src/Resources/public/js/order-edit.js
+++ b/src/Resources/public/js/order-edit.js
@@ -1,24 +1,32 @@
-window.addEventListener('DOMContentLoaded', (event) => {
-    document.querySelectorAll('button.delete-order-item').forEach((button) => {
-        button.addEventListener('click', (event) => {
-            const orderLineId = event.currentTarget.closest('tr').remove();
-        });
+document.querySelectorAll('button.delete-order-item').forEach((button) => {
+    button.addEventListener('click', (event) => {
+        var row = event.currentTarget.parentElement.parentElement;
+        row.nextElementSibling.remove();
+        row.remove();
     });
+});
 
-    document.querySelector('button.add-order-item').addEventListener('click', (event) => {
-        const orderItemTable = event.currentTarget.closest('table');
+document.querySelector('button.add-order-item').addEventListener('click', (event) => {
+    const orderItemTable = event.currentTarget.closest('table');
 
-        const html = orderItemTable
-            .dataset
-            .prototype
-            .replace(
-                /__name__/g,
-                orderItemTable.dataset.index
-            )
-        ;
+    const html = orderItemTable
+        .dataset
+        .prototype
+        .replace(
+            /__name__/g,
+            orderItemTable.dataset.index
+        )
+    ;
 
-        orderItemTable.querySelector('tbody').insertAdjacentHTML('beforeend', html)
+    orderItemTable.querySelector('tbody').insertAdjacentHTML('beforeend', html)
 
-        orderItemTable.dataset.index++;
+    orderItemTable.dataset.index++;
+
+    var rows = orderItemTable.querySelectorAll('form[name="sylius_order"] tbody tr');
+    var lastItemRowDeleteButton = rows[rows.length - 2].querySelector('button.delete-order-item');
+    lastItemRowDeleteButton.addEventListener('click', (event) => {
+        var row = event.currentTarget.parentElement.parentElement;
+        row.nextElementSibling.remove();
+        row.remove();
     });
 });

--- a/src/Resources/public/js/order-edit.js
+++ b/src/Resources/public/js/order-edit.js
@@ -1,6 +1,6 @@
 document.querySelectorAll('button.delete-order-item').forEach((button) => {
     button.addEventListener('click', (event) => {
-        var row = event.currentTarget.parentElement.parentElement;
+        var row = event.currentTarget.closest('tr');
         row.nextElementSibling.remove();
         row.remove();
     });
@@ -25,7 +25,7 @@ document.querySelector('button.add-order-item').addEventListener('click', (event
     var rows = orderItemTable.querySelectorAll('form[name="sylius_order"] tbody tr');
     var lastItemRowDeleteButton = rows[rows.length - 2].querySelector('button.delete-order-item');
     lastItemRowDeleteButton.addEventListener('click', (event) => {
-        var row = event.currentTarget.parentElement.parentElement;
+        var row = event.currentTarget.closest('tr');
         row.nextElementSibling.remove();
         row.remove();
     });

--- a/src/Resources/views/admin/order/update/_order_items.html.twig
+++ b/src/Resources/views/admin/order/update/_order_items.html.twig
@@ -40,8 +40,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="5">{{ form_widget(itemForm.discounts) }}</td>
-                    <td></td>
+                    <td colspan="6">{{ form_widget(itemForm.discounts) }}</td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/src/Resources/views/admin/order/update/theme.html.twig
+++ b/src/Resources/views/admin/order/update/theme.html.twig
@@ -1,9 +1,17 @@
 {% extends '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block _sylius_order_items_entry_widget %}
-    <tr>
+    <tr class="item">
         <td>{{ form_widget(form.quantity) }}</td>
         <td>{{ form_widget(form.variant) }}</td>
-        <td colspan="3">&nbsp;</td>
+        <td colspan="4" class="right aligned">
+            <button class="ui red labeled icon button delete-order-item" type="button">
+                <i class="icon trash"></i> {{ 'sylius.ui.delete'|trans }}
+            </button>
+        </td>
+    </tr>
+    <tr class="item-discounts">
+        {# TODO: enable disounts for new order item as well #}
+        {# <td colspan="6">{{ form_widget(form.discounts) }}</td>#}
     </tr>
 {% endblock %}

--- a/src/Setter/OrderDiscountAdjustmentSetter.php
+++ b/src/Setter/OrderDiscountAdjustmentSetter.php
@@ -21,8 +21,7 @@ final class OrderDiscountAdjustmentSetter implements OrderDiscountAdjustmentSett
     public function set(OrderInterface $order, int $discount): void
     {
         $items = $order->getItems();
-        /** @var int $orderId */
-        $orderId = $order->getId();
+        $orderId = (int) $order->getId();
 
         $distributedPrices = $this->integerDistributor->distribute($discount, $items->count());
 


### PR DESCRIPTION
Fixes #15 

https://github.com/Setono/sylius-order-edit-plugin/assets/6212718/2f35e155-ef1e-4470-8a9c-cb6ae34f8e38

What still don't work are discounts for the new order item - but it was not in a issue description :dancer: So didn't want to be too hasty with implementing such a feature (and, obviously, the delete button is more crucial)