### PR TITLE
Additional installation step on Sylius 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ setono_sylius_order_edit:
     resource: "@SetonoSyliusOrderEditPlugin/Resources/config/routes.yaml"
 ```
 
+If you're using Sylius 1.10, import also additional product variant route:
+
+```yaml
+setono_sylius_order_edit_product_variant:
+    resource: "@SetonoSyliusOrderEditPlugin/Resources/config/routes/product_variant.yaml"
+```
+
 ### Extend the `Order` entity
 
 ```php

--- a/src/Resources/config/routes/product_variant.yaml
+++ b/src/Resources/config/routes/product_variant.yaml
@@ -1,0 +1,17 @@
+# Route configured in Sylius 1.11+
+# Check out https://github.com/Sylius/Sylius/blob/1.11/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml#L26
+sylius_admin_ajax_all_product_variants_by_phrase:
+    path: /search-all
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.product_variant::indexAction
+        _format: json
+        _sylius:
+            serialization_groups: [Autocomplete]
+            permission: true
+            repository:
+                method: findByPhrase
+                arguments:
+                    phrase: $phrase
+                    locale: expr:service('sylius.context.locale').getLocaleCode()
+                    limit: "!!int %sylius.ajax.product.variant_autocomplete_limit%"


### PR DESCRIPTION
This is the easiest way to solve https://github.com/Setono/sylius-order-edit-plugin/issues/32
We could in theory play with some custom route loader, but IMO it's not worth it. It's only one more step of installation and makes it explicitly what is needed to make the plugin work in 1.10 🖖 

Btw, maybe it's worth having at least one job running Sylius 1.10 if we see such problems? 🤔 Something to think about