### PR TITLE
Fix possible throwing of exception when reordering menu items

### DIFF
--- a/src/EventSubscriber/OrderShowMenuSubscriber.php
+++ b/src/EventSubscriber/OrderShowMenuSubscriber.php
@@ -11,6 +11,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class OrderShowMenuSubscriber implements EventSubscriberInterface
 {
+    private const MENU_ITEM_KEY = 'edit';
+
     public static function getSubscribedEvents(): array
     {
         return [OrderShowMenuBuilder::EVENT_NAME => 'addEditButton'];
@@ -27,7 +29,7 @@ final class OrderShowMenuSubscriber implements EventSubscriberInterface
 
         $menu
             ->addChild(
-                'edit',
+                self::MENU_ITEM_KEY,
                 [
                     'route' => 'sylius_admin_order_update',
                     'routeParameters' => ['id' => $order->getId()],
@@ -39,6 +41,12 @@ final class OrderShowMenuSubscriber implements EventSubscriberInterface
             ->setLabelAttribute('color', 'purple')
         ;
 
-        $menu->reorderChildren(['edit', 'order_history', 'cancel']);
+        $sort = [self::MENU_ITEM_KEY, 'order_history', 'cancel'];
+        $rest = array_diff(array_keys($menu->getChildren()), $sort);
+
+        try {
+            $event->getMenu()->reorderChildren(array_merge($sort, $rest));
+        } catch (\InvalidArgumentException) {
+        }
     }
 }


### PR DESCRIPTION
Fixes an exception like this:

```
Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Cannot reorder children, order does not contain all children.")." at .../public_html/releases/81/vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_headerWidget.html.twig line 6
```