### PR TITLE
Do not touch payments on edited orders

### DIFF
--- a/src/Checker/OrderPaymentEditionChecker.php
+++ b/src/Checker/OrderPaymentEditionChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusOrderEditPlugin\Checker;
+
+use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Order\Model\OrderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Webmozart\Assert\Assert;
+
+final class OrderPaymentEditionChecker implements OrderPaymentEditionCheckerInterface
+{
+    public function __construct(private readonly RequestStack $requestStack)
+    {
+    }
+
+    public function shouldOrderPaymentBeEdited(OrderInterface $order): bool
+    {
+        Assert::isInstanceOf($order, \Sylius\Component\Core\Model\OrderInterface::class);
+
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return true;
+        }
+
+        if ('setono_sylius_order_edit_admin_update' !== $request->attributes->get('_route')) {
+            return true;
+        }
+
+        return $order->getPaymentState() === OrderPaymentStates::STATE_AWAITING_PAYMENT;
+    }
+}

--- a/src/Checker/OrderPaymentEditionCheckerInterface.php
+++ b/src/Checker/OrderPaymentEditionCheckerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusOrderEditPlugin\Checker;
+
+use Sylius\Component\Order\Model\OrderInterface;
+
+interface OrderPaymentEditionCheckerInterface
+{
+    public function shouldOrderPaymentBeEdited(OrderInterface $order): bool;
+}

--- a/src/Checker/PostCheckoutOrderPaymentEditionChecker.php
+++ b/src/Checker/PostCheckoutOrderPaymentEditionChecker.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Setono\SyliusOrderEditPlugin\Checker;
 
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Order\Model\OrderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\Assert\Assert;
 
-final class OrderPaymentEditionChecker implements OrderPaymentEditionCheckerInterface
+final class PostCheckoutOrderPaymentEditionChecker implements OrderPaymentEditionCheckerInterface
 {
     public function __construct(private readonly RequestStack $requestStack)
     {
@@ -23,6 +24,10 @@ final class OrderPaymentEditionChecker implements OrderPaymentEditionCheckerInte
             return true;
         }
 
-        return 'setono_sylius_order_edit_admin_update' !== $request->attributes->get('_route');
+        if ('setono_sylius_order_edit_admin_update' !== $request->attributes->get('_route')) {
+            return true;
+        }
+
+        return $order->getPaymentState() === OrderPaymentStates::STATE_AWAITING_PAYMENT;
     }
 }

--- a/src/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/OrderProcessing/OrderPaymentProcessor.php
@@ -4,26 +4,21 @@ declare(strict_types=1);
 
 namespace Setono\SyliusOrderEditPlugin\OrderProcessing;
 
+use Setono\SyliusOrderEditPlugin\Checker\OrderPaymentEditionCheckerInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 final class OrderPaymentProcessor implements OrderProcessorInterface
 {
     public function __construct(
         private readonly OrderProcessorInterface $decorated,
-        private readonly RequestStack $requestStack,
+        private readonly OrderPaymentEditionCheckerInterface $orderPaymentEditionChecker,
     ) {
     }
 
     public function process(OrderInterface $order): void
     {
-        /** @var mixed $route */
-        $route = $this->requestStack->getCurrentRequest()?->attributes->get('_route');
-
-        // This disables the \Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor if the route is 'setono_sylius_order_edit_admin_update'
-        // which means we are editing the order in the admin panel
-        if ('setono_sylius_order_edit_admin_update' === $route) {
+        if (!$this->orderPaymentEditionChecker->shouldOrderPaymentBeEdited($order)) {
             return;
         }
 

--- a/src/Resources/config/services/order_processing.xml
+++ b/src/Resources/config/services/order_processing.xml
@@ -2,11 +2,29 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="setono_sylius_order_edit.order_processing.order_payment_processor"
-                 class="Setono\SyliusOrderEditPlugin\OrderProcessing\OrderPaymentProcessor"
-                 decorates="sylius.order_processing.order_payment_processor.checkout" decoration-priority="64">
+        <service
+            id="setono_sylius_order_edit.order_processing.order_payment_processor"
+            class="Setono\SyliusOrderEditPlugin\OrderProcessing\OrderPaymentProcessor"
+            decorates="sylius.order_processing.order_payment_processor.checkout" decoration-priority="64"
+        >
             <argument type="service" id="setono_sylius_order_edit.order_processing.order_payment_processor.inner"/>
-            <argument type="service" id="request_stack"/>
+            <argument type="service" id="setono_sylius_order_edit.checker.order_payment_edition"/>
+        </service>
+
+        <service
+            id="setono_sylius_order_edit.order_processing.order_payment_processor.after_checkout"
+            class="Setono\SyliusOrderEditPlugin\OrderProcessing\OrderPaymentProcessor"
+            decorates="sylius.order_processing.order_payment_processor.after_checkout" decoration-priority="64"
+        >
+            <argument type="service" id="setono_sylius_order_edit.order_processing.order_payment_processor.after_checkout.inner"/>
+            <argument type="service" id="setono_sylius_order_edit.checker.order_payment_edition"/>
+        </service>
+
+        <service
+            id="setono_sylius_order_edit.checker.order_payment_edition"
+            class="Setono\SyliusOrderEditPlugin\Checker\OrderPaymentEditionChecker"
+        >
+            <argument type="service" id="request_stack" />
         </service>
 
         <service

--- a/src/Resources/config/services/order_processing.xml
+++ b/src/Resources/config/services/order_processing.xml
@@ -17,12 +17,19 @@
             decorates="sylius.order_processing.order_payment_processor.after_checkout" decoration-priority="64"
         >
             <argument type="service" id="setono_sylius_order_edit.order_processing.order_payment_processor.after_checkout.inner"/>
-            <argument type="service" id="setono_sylius_order_edit.checker.order_payment_edition"/>
+            <argument type="service" id="setono_sylius_order_edit.checker.order_payment_edition.post_checkout"/>
         </service>
 
         <service
             id="setono_sylius_order_edit.checker.order_payment_edition"
             class="Setono\SyliusOrderEditPlugin\Checker\OrderPaymentEditionChecker"
+        >
+            <argument type="service" id="request_stack" />
+        </service>
+
+        <service
+            id="setono_sylius_order_edit.checker.order_payment_edition.post_checkout"
+            class="Setono\SyliusOrderEditPlugin\Checker\PostCheckoutOrderPaymentEditionChecker"
         >
             <argument type="service" id="request_stack" />
         </service>

--- a/tests/Unit/Checker/OrderPaymentEditionCheckerTest.php
+++ b/tests/Unit/Checker/OrderPaymentEditionCheckerTest.php
@@ -7,8 +7,7 @@ namespace Setono\SyliusOrderEditPlugin\Tests\Unit\Checker;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusOrderEditPlugin\Checker\OrderPaymentEditionChecker;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderPaymentStates;
+use Sylius\Component\Core\Model\Order;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -16,56 +15,38 @@ final class OrderPaymentEditionCheckerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testItSaysOrderPaymentsShouldNotBeEditedIfTheRouteIsOrderEditAndThePaymentIsAlreadyProcessed(): void
+    public function testItSaysOrderPaymentsShouldNotBeEditedIfTheRouteIsOrderEdit(): void
     {
         $requestStack = $this->prophesize(RequestStack::class);
         $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
         $requestStack->getCurrentRequest()->willReturn($request);
 
         $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+        $order = new Order();
 
-        $order = $this->prophesize(OrderInterface::class);
-        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AUTHORIZED);
-
-        self::assertFalse($checker->shouldOrderPaymentBeEdited($order->reveal()));
+        self::assertFalse($checker->shouldOrderPaymentBeEdited($order));
     }
 
-    public function testItSaysOrderPaymentShouldBeEditedItTheRouteIsOrderEditButOrderIsAwaitingPayment(): void
-    {
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
-        $requestStack->getCurrentRequest()->willReturn($request);
-
-        $checker = new OrderPaymentEditionChecker($requestStack->reveal());
-
-        $order = $this->prophesize(OrderInterface::class);
-        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
-
-        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
-    }
-
-    public function testItSaysOrderPaymentShouldBeEditedIfItsNotOrderEditRoute(): void
+    public function testItSaysOrderPaymentCanBeEditedIfItsNotOrderEditRoute(): void
     {
         $requestStack = $this->prophesize(RequestStack::class);
         $request = new Request([], [], ['_route' => 'sylius_admin_order_any_other_route']);
         $requestStack->getCurrentRequest()->willReturn($request);
 
         $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+        $order = new Order();
 
-        $order = $this->prophesize(OrderInterface::class);
-
-        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order));
     }
 
-    public function testItSaysOrderPaymentShouldBeEditedIfThereIsNoCurrentRequest(): void
+    public function testItSaysOrderPaymentCanBeEditedIfThereIsNoCurrentRequest(): void
     {
         $requestStack = $this->prophesize(RequestStack::class);
         $requestStack->getCurrentRequest()->willReturn(null);
 
         $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+        $order = new Order();
 
-        $order = $this->prophesize(OrderInterface::class);
-
-        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order));
     }
 }

--- a/tests/Unit/Checker/OrderPaymentEditionCheckerTest.php
+++ b/tests/Unit/Checker/OrderPaymentEditionCheckerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusOrderEditPlugin\Tests\Unit\Checker;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusOrderEditPlugin\Checker\OrderPaymentEditionChecker;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class OrderPaymentEditionCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testItSaysOrderPaymentsShouldNotBeEditedIfTheRouteIsOrderEditAndThePaymentIsAlreadyProcessed(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AUTHORIZED);
+
+        self::assertFalse($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedItTheRouteIsOrderEditButOrderIsAwaitingPayment(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedIfItsNotOrderEditRoute(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'sylius_admin_order_any_other_route']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedIfThereIsNoCurrentRequest(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $requestStack->getCurrentRequest()->willReturn(null);
+
+        $checker = new OrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+}

--- a/tests/Unit/Checker/PostCheckoutOrderPaymentEditionCheckerTest.php
+++ b/tests/Unit/Checker/PostCheckoutOrderPaymentEditionCheckerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusOrderEditPlugin\Tests\Unit\Checker;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\SyliusOrderEditPlugin\Checker\PostCheckoutOrderPaymentEditionChecker;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderPaymentStates;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class PostCheckoutOrderPaymentEditionCheckerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testItSaysOrderPaymentsShouldNotBeEditedIfTheRouteIsOrderEditAndThePaymentIsAlreadyProcessed(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new PostCheckoutOrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AUTHORIZED);
+
+        self::assertFalse($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedItTheRouteIsOrderEditButOrderIsAwaitingPayment(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'setono_sylius_order_edit_admin_update']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new PostCheckoutOrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_AWAITING_PAYMENT);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedIfItsNotOrderEditRoute(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $request = new Request([], [], ['_route' => 'sylius_admin_order_any_other_route']);
+        $requestStack->getCurrentRequest()->willReturn($request);
+
+        $checker = new PostCheckoutOrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+
+    public function testItSaysOrderPaymentShouldBeEditedIfThereIsNoCurrentRequest(): void
+    {
+        $requestStack = $this->prophesize(RequestStack::class);
+        $requestStack->getCurrentRequest()->willReturn(null);
+
+        $checker = new PostCheckoutOrderPaymentEditionChecker($requestStack->reveal());
+
+        $order = $this->prophesize(OrderInterface::class);
+
+        self::assertTrue($checker->shouldOrderPaymentBeEdited($order->reveal()));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/Setono/sylius-order-edit-plugin/issues/38

There are two order payment processors in Sylius. The second one is handling payments on the completed orders and that's the one that resulted in a bug. Decorating it should fix the problem 🖖 

The video shows that when editing the order that is not paid the payment amount would be changed as well, but when doing so on the paid order payments are not touched at all:

https://github.com/user-attachments/assets/0ca55501-73c0-41c2-b7a9-778e30d6a214